### PR TITLE
[mlir][affine][vector] add memref access dependency analysis support for vector

### DIFF
--- a/mlir/include/mlir/Dialect/Affine/Analysis/AffineAnalysis.h
+++ b/mlir/include/mlir/Dialect/Affine/Analysis/AffineAnalysis.h
@@ -81,6 +81,7 @@ struct MemRefAccess {
   Value memref;
   Operation *opInst;
   SmallVector<Value, 4> indices;
+  SmallVector<int64_t, 4> accessRange;
 
   /// Constructs a MemRefAccess from a load or store operation.
   // TODO: add accessors to standard op's load, store, DMA op's to return

--- a/mlir/include/mlir/Dialect/Affine/Analysis/AffineStructures.h
+++ b/mlir/include/mlir/Dialect/Affine/Analysis/AffineStructures.h
@@ -672,9 +672,11 @@ AffineMap alignAffineMapWithValues(AffineMap map, ValueRange operands,
 /// For AffineValueMap, the domain and symbols have Value set corresponding to
 /// the Value in `map`. Returns failure if the AffineMap could not be flattened
 /// (i.e., semi-affine is not yet handled).
-LogicalResult getRelationFromMap(AffineMap &map, FlatAffineRelation &rel);
+LogicalResult getRelationFromMap(AffineMap &map, FlatAffineRelation &rel,
+                                 const SmallVectorImpl<int64_t> &accessRange);
 LogicalResult getRelationFromMap(const AffineValueMap &map,
-                                 FlatAffineRelation &rel);
+                                 FlatAffineRelation &rel,
+                                 const SmallVectorImpl<int64_t> &accessRange);
 
 } // namespace mlir.
 


### PR DESCRIPTION
this pr enhances memref access dependence analysis by adding support for vector/block access.
for a scalar memory access - a[i][j], its access is represented as i*stridej + j
so for a vector/block memory access - a[i][j:j+4], its access can be represented as i * stridej + j + n, in which n is a local variable in the affine expression.
with this, the later ILP can work correctly.